### PR TITLE
Ensure user filter is applied to json and non-json list output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloud-workstation"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.8"
 readme = "README.md"
 description = ""

--- a/src/workstation/cli/crud.py
+++ b/src/workstation/cli/crud.py
@@ -348,8 +348,12 @@ def list(
             config_branch.add(f"User: {result['user']}", style="white")
             config_branch.add(f":minidisc: Image: {result['image']}")
             config_branch.add(f":computer: Machine Type: {result['type']}")
-            config_branch.add(f":hourglass_flowing_sand: Idle Timeout (s): {str(result['idle_timeout'])}")
-            config_branch.add(f":hourglass_flowing_sand: Max Runtime (s): {str(result['max_runtime'])}")
+            config_branch.add(
+                f":hourglass_flowing_sand: Idle Timeout (s): {str(result['idle_timeout'])}"
+            )
+            config_branch.add(
+                f":hourglass_flowing_sand: Max Runtime (s): {str(result['max_runtime'])}"
+            )
 
         console.print(tree)
         console.print("Total Workstations: ", len(tree.children))

--- a/src/workstation/cli/crud.py
+++ b/src/workstation/cli/crud.py
@@ -305,65 +305,54 @@ def list(
         location=location,
     )
 
-    if not export_json:
+    results = []
+    for workstation in workstations:
+        if not all and workstation.get("env", {}).get("LDAP") != user:
+            continue
+
+        result = {
+            "name": workstation["name"].split("/")[-1],
+            "user": workstation["env"]["LDAP"],
+            "project": workstation["project"],
+            "location": workstation["location"],
+            "config": workstation["config"]["name"].split("/")[-1],
+            "cluster": workstation["cluster"],
+            "state": workstation["state"].name,
+            "idle_timeout": workstation["config"]["idle_timeout"],
+            "max_runtime": workstation["config"]["max_runtime"],
+            "type": workstation["config"]["machine_type"],
+            "image": workstation["config"]["image"],
+        }
+        results.append(result)
+
+    if export_json:
+        json_data = json.dumps(results, indent=4)
+        console.print(json_data)
+    else:
         tree = Tree("Workstations", style="bold blue")
 
-        for workstation in workstations:
-            if not all and workstation.get("env", {}).get("LDAP") != user:
-                continue
-
-            if workstation["state"].name == "STATE_RUNNING":
+        for result in results:
+            if result["state"] == "STATE_RUNNING":
                 status = ":play_button: Running"
-            elif workstation["state"].name == "STATE_STOPPED":
+            elif result["state"] == "STATE_STOPPED":
                 status = ":stop_sign: Stopped"
-            elif workstation["state"].name == "STATE_STARTING":
+            elif result["state"] == "STATE_STARTING":
                 status = ":hourglass: Starting"
-            elif workstation["state"].name == "STATE_STOPPING":
+            elif result["state"] == "STATE_STOPPING":
                 status = ":hourglass: Stopping"
             else:
                 status = ":question: State unknown"
 
-            config_branch = tree.add(
-                f"Workstation: {workstation['name'].split('/')[-1]}"
-            )
+            config_branch = tree.add(f"Workstation: {result['name']}")
             config_branch.add(f"{status}", style="white")
-            config_branch.add(f"User: {workstation['env']['LDAP']}", style="white")
-            config_branch.add(f":minidisc: Image: {workstation['config']['image']}")
-            config_branch.add(
-                f":computer: Machine Type: {workstation['config']['machine_type']}"
-            )
-            config_branch.add(
-                f":hourglass_flowing_sand: Idle Timeout (s): {str(workstation['config']['idle_timeout'])}"
-            )
-            config_branch.add(
-                f":hourglass_flowing_sand: Max Runtime (s): {str(workstation['config']['max_runtime'])}"
-            )
+            config_branch.add(f"User: {result['user']}", style="white")
+            config_branch.add(f":minidisc: Image: {result['image']}")
+            config_branch.add(f":computer: Machine Type: {result['type']}")
+            config_branch.add(f":hourglass_flowing_sand: Idle Timeout (s): {str(result['idle_timeout'])}")
+            config_branch.add(f":hourglass_flowing_sand: Max Runtime (s): {str(result['max_runtime'])}")
 
         console.print(tree)
         console.print("Total Workstations: ", len(tree.children))
-    else:
-        results = []
-        for workstation in workstations:
-            if not all and workstation.get("env", {}).get("LDAP") != user:
-                continue
-
-            result = {}
-            result["name"] = workstation["name"].split("/")[-1]
-            result["user"] = workstation["env"]["LDAP"]
-            result["user"] = workstation["env"]["LDAP"]
-            result["project"] = workstation["project"]
-            result["location"] = workstation["location"]
-            result["config"] = workstation["config"]["name"].split("/")[-1]
-            result["cluster"] = workstation["cluster"]
-            result["state"] = workstation["state"].name
-            result["idle_timeout"] = workstation["config"]["idle_timeout"]
-            result["max_runtime"] = workstation["config"]["max_runtime"]
-            result["type"] = workstation["config"]["machine_type"]
-            result["image"] = workstation["config"]["image"]
-            results.append(result)
-
-        json_data = json.dumps(results, indent=4)
-        console.print(json_data)
 
 
 @command()

--- a/src/workstation/cli/crud.py
+++ b/src/workstation/cli/crud.py
@@ -344,6 +344,9 @@ def list(
     else:
         results = []
         for workstation in workstations:
+            if not all and workstation.get("env", {}).get("LDAP") != user:
+                continue
+
             result = {}
             result["name"] = workstation["name"].split("/")[-1]
             result["user"] = workstation["env"]["LDAP"]

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -86,12 +86,36 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
 
     result = runner.invoke(crud.list, ["--user", "test-user"])
     assert result.exit_code == 0
-    assert "workstation1" in result.output
-    assert "User: test-user" in result.output
-    assert "User: other-user" not in result.output
+    expected_tree_output = (
+        "Workstations\n"
+        "└── Workstation: workstation1\n"
+        "    ├── ▶ Running\n"
+        "    ├── User: test-user\n"
+        "    ├── 💽 Image: test-image\n"
+        "    ├── 💻 Machine Type: n1-standard-4\n"
+        "    ├── ⏳ Idle Timeout (s): 3600\n"
+        "    └── ⏳ Max Runtime (s): 7200\n"
+        "Total Workstations:  1\n"
+    )
+    
+    assert result.output == expected_tree_output
 
     result = runner.invoke(crud.list, ["--user", "test-user", "--json"])
-    assert result.exit_code == 0
-    assert "workstation1" in result.output
-    assert "\"user\": \"test-user\"" in result.output
-    assert "\"user\": \"other-user\"" not in result.output
+    expected_json_output = (
+        '[\n'
+        '    {\n'
+        '        "name": "workstation1",\n'
+        '        "user": "test-user",\n'
+        '        "project": "test-project",\n'
+        '        "location": "us-central1",\n'
+        '        "config": "config-name",\n'
+        '        "cluster": "cluster-public",\n'
+        '        "state": "STATE_RUNNING",\n'
+        '        "idle_timeout": 3600,\n'
+        '        "max_runtime": 7200,\n'
+        '        "type": "n1-standard-4",\n'
+        '        "image": "test-image"\n'
+        '    }\n'
+        ']\n'
+    )
+    assert result.output == expected_json_output

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -54,20 +54,44 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
     mock_list_workstations.return_value = [
         {
             "name": "workstation1",
-            "state": workstation_state,
+            "project": "test-project",
+            "location": "us-central1",
+            "cluster": "cluster-public",
+            "state": type('obj', (object,), {'name' : 'STATE_RUNNING'})(),
             "env": {"LDAP": "test-user"},
             "config": {
+                "name": "this/config-name",
                 "image": "test-image",
                 "machine_type": "n1-standard-4",
                 "idle_timeout": 3600,
                 "max_runtime": 7200,
             },
+        },
+        {
+            "name": "workstation2",
+            "project": "test-project",
+            "location": "us-central1",
+            "cluster": "cluster-public",
+            "state": type('obj', (object,), {'name' : 'STATE_STOPPED'})(),
+            "env": {"LDAP": "other-user"},
+            "config": {
+                "name": "this/config-name",
+                "image": "test-image",
+                "machine_type": "n1-standard-4",
+                "idle_timeout": 3600,
+                "max_runtime": 7200,
+            }
         }
     ]
 
     result = runner.invoke(crud.list, ["--user", "test-user"])
-    print(result.output)
-
     assert result.exit_code == 0
     assert "workstation1" in result.output
-    assert "\u25b6 Running" in result.output
+    assert "User: test-user" in result.output
+    assert "User: other-user" not in result.output
+
+    result = runner.invoke(crud.list, ["--user", "test-user", "--json"])
+    assert result.exit_code == 0
+    assert "workstation1" in result.output
+    assert "\"user\": \"test-user\"" in result.output
+    assert "\"user\": \"other-user\"" not in result.output

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -57,7 +57,7 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
             "project": "test-project",
             "location": "us-central1",
             "cluster": "cluster-public",
-            "state": type('obj', (object,), {'name' : 'STATE_RUNNING'})(),
+            "state": type("obj", (object,), {"name": "STATE_RUNNING"})(),
             "env": {"LDAP": "test-user"},
             "config": {
                 "name": "this/config-name",
@@ -72,7 +72,7 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
             "project": "test-project",
             "location": "us-central1",
             "cluster": "cluster-public",
-            "state": type('obj', (object,), {'name' : 'STATE_STOPPED'})(),
+            "state": type("obj", (object,), {"name": "STATE_STOPPED"})(),
             "env": {"LDAP": "other-user"},
             "config": {
                 "name": "this/config-name",
@@ -80,8 +80,8 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
                 "machine_type": "n1-standard-4",
                 "idle_timeout": 3600,
                 "max_runtime": 7200,
-            }
-        }
+            },
+        },
     ]
 
     result = runner.invoke(crud.list, ["--user", "test-user"])
@@ -97,13 +97,13 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
         "    └── ⏳ Max Runtime (s): 7200\n"
         "Total Workstations:  1\n"
     )
-    
+
     assert result.output == expected_tree_output
 
     result = runner.invoke(crud.list, ["--user", "test-user", "--json"])
     expected_json_output = (
-        '[\n'
-        '    {\n'
+        "[\n"
+        "    {\n"
         '        "name": "workstation1",\n'
         '        "user": "test-user",\n'
         '        "project": "test-project",\n'
@@ -115,7 +115,7 @@ def test_list(mock_get_gcloud_config, mock_check_gcloud_auth, mock_list_workstat
         '        "max_runtime": 7200,\n'
         '        "type": "n1-standard-4",\n'
         '        "image": "test-image"\n'
-        '    }\n'
-        ']\n'
+        "    }\n"
+        "]\n"
     )
     assert result.output == expected_json_output


### PR DESCRIPTION
I hit a bug where when running `workstation list --json` the filtering behaviour was different to the non-json version

* non-json: output for current user
* --json: output all workstations

I've made it consistent, and then refactored the code a little so we only loop once, filter once, and then either present it as json or the tree. 